### PR TITLE
kotlin & coroutines & retrofit version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.1.1"
+    id "org.jetbrains.kotlin.jvm" version "1.1.2"
     id "com.jfrog.bintray" version "1.7.3" apply false
 }
 
 group 'ru.gildor.coroutines'
-version '0.5.0'
+version '0.5.1'
 
 repositories {
     jcenter()
@@ -22,8 +22,8 @@ sourceSets {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${plugins.findPlugin("kotlin").properties["kotlinPluginVersion"]}"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.14"
-    compile 'com.squareup.retrofit2:retrofit:2.2.0'
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.16"
+    compile 'com.squareup.retrofit2:retrofit:2.3.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
+++ b/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
@@ -17,7 +17,7 @@ suspend fun <T> Call<T>.await(): T {
         enqueue(object : Callback<T> {
             override fun onResponse(call: Call<T>?, response: Response<T>) {
                 if (response.isSuccessful) {
-                    continuation.resume(response.body())
+                    continuation.resume(response.body() as T)
                 } else {
                     continuation.resumeWithException(HttpException(response))
                 }
@@ -69,7 +69,7 @@ suspend fun <T> Call<T>.awaitResult(): Result<T> {
             override fun onResponse(call: Call<T>?, response: Response<T>) {
                 continuation.resume(
                         if (response.isSuccessful) {
-                            Result.Ok(response.body(), response.raw())
+                            Result.Ok(response.body() as T, response.raw())
                         } else {
                             Result.Error(HttpException(response), response.raw())
                         }

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/CallAwaitTest.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/CallAwaitTest.kt
@@ -125,7 +125,7 @@ class CallAwaitTest {
             is Result.Error -> {
                 assertEquals(error.code(), result.exception.code())
                 assertEquals(error.message, result.exception.message)
-                assertEquals("Error response 500", result.exception.response().errorBody().string())
+                assertEquals("Error response 500", result.exception.response().errorBody()?.string())
                 assertEquals(500, result.response.code())
             }
             is Result.Ok, is Result.Exception -> fail()

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/util/MockedCall.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/util/MockedCall.kt
@@ -61,5 +61,6 @@ fun errorResponse(code: Int = 400, message: String = "Error response $code"): Re
 fun okHttpResponse(code: Int = 200): okhttp3.Response = okhttp3.Response.Builder()
         .code(code)
         .protocol(Protocol.HTTP_1_1)
+        .message("mock response")
         .request(Request.Builder().url("http://localhost").build())
         .build()


### PR DESCRIPTION
This PR fixes runtime issues (such as one described below) by just upgrading to newest versions of kotlin and libs

```
Caused by: java.lang.NoSuchMethodError: No direct method <init>(Lkotlin/coroutines/experimental/Continuation;Z)V in class Lkotlinx/coroutines/experimental/CancellableContinuationImpl; or its super classes (declaration of 'kotlinx.coroutines.experimental.CancellableContinuationImpl' appears in /data/app/my.company.app-1/split_lib_dependencies_apk.apk)
                                                                               at ru.gildor.coroutines.retrofit.CallAwaitKt.awaitResult(CallAwait.kt:124)
                                                                               at my.company.app.login.LoginInteractor$login$1$1.doResume(LoginInteractor.kt:25)
                                                                               at kotlin.coroutines.experimental.jvm.internal.CoroutineImpl.resume(CoroutineImpl.kt:54)
                                                                               at kotlinx.coroutines.experimental.DispatchTask.run(CoroutineDispatcher.kt:235)
                                                                               at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1383)
                                                                               at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:256)
                                                                               at java.util.concurrent.ForkJoinPool$WorkQueue.localPopAndExec(ForkJoinPool.java:1083)
                                                                               at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1127)
                                                                               at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1961)
                                                                               at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1909)
                                                                               at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:128)
```