### PR TITLE
v0.6.0: Nullable body handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # CHANGELOG
 
+## Version 0.6.0 (2017-07-04)
+
+Notice: This release backward incompatible with previous versions:
+
+`.await()` and `.awaitResult()` can be used now only with non-nullable types of result 
+and throw NullPointerException in case of null body. 
+See [examples in Readme](README.md#Nullable body)
+
 ## Version 0.5.1 (2017-06-27)
 
+- [Retrofit 2.3.0](https://github.com/square/retrofit/blob/parent-2.3.0/CHANGELOG.md#version-230-2017-05-13)
 - [kotlinx.coroutines 0.16](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/0.16)
 - Compiled against Kotlin 1.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 Notice: This release backward incompatible with previous versions:
 
-`.await()` and `.awaitResult()` can be used now only with non-nullable types of result 
+- `.await()` and `.awaitResult()` can be used now only with non-nullable types of result 
 and throw NullPointerException in case of null body. 
 See [examples in Readme](README.md#Nullable body)
+- [#13](https://github.com/gildor/kotlin-coroutines-retrofit/issues/13) `.toString()` for `Result` classes
 
 ## Version 0.5.1 (2017-06-27)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Download the [JAR](https://bintray.com/gildor/maven/kotlin-coroutines-retrofit#f
 Gradle:
 
 ```groovy
-compile 'ru.gildor.coroutines:kotlin-coroutines-retrofit:0.5.1'
+compile 'ru.gildor.coroutines:kotlin-coroutines-retrofit:0.6.0'
 ```
 
 Maven:
@@ -19,7 +19,7 @@ Maven:
 <dependency>
   <groupId>ru.gildor.coroutines</groupId>
   <artifactId>kotlin-coroutines-retrofit</artifactId>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
 </dependency>
 ```
 
@@ -143,3 +143,35 @@ fun main(args: Array<String>) = runBlocking {
   }
 }
 ```
+
+## Nullable body
+
+To prevent unexpected behavior with nullable body of response `Call<Body?>`
+extensions `.await()` and `.awaitResult()` awailable only for 
+non nullable `Call<Body>` or platform `Call<Body!>` body types:
+
+```kotlin
+fun main(args: Array<String>) = runBlocking {
+  val user: Call<User> = api.getUser("username")
+  val userOrNull: Call<User?> = api.getUserOrNull("username")
+  
+  // Doesn't work, because User is nullable
+  // userOrNull.await()
+    
+  // Works for non-nullable type
+  try {
+      val result: User = user.await()  
+  } catch (e: NullPointerException) {
+      // If body will be null you will get NullPointerException
+  }
+  
+  // You can use .awaitResult() to catch possible problems with nullable body
+  val nullableResult = api.getUser("username").awaitResult().getOrNull()
+  // But type of body should be non-nullable
+  // api.getUserOrNull("username").awaitResult()
+  
+  // If you still want to use nullable body to clarify your api
+  // use awaitResponse() instead:
+  val responseBody: User? = userOrNull.awaitResponse().body()
+}
+``` 

--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,11 @@ plugins {
 }
 
 group 'ru.gildor.coroutines'
-version '0.5.1'
+version '0.6.0'
 
 repositories {
     jcenter()
 }
-
-apply plugin: 'kotlin'
 
 targetCompatibility = '1.6'
 sourceCompatibility = '1.6'

--- a/src/main/kotlin/ru/gildor/coroutines/retrofit/Result.kt
+++ b/src/main/kotlin/ru/gildor/coroutines/retrofit/Result.kt
@@ -4,22 +4,22 @@ import okhttp3.Response
 import retrofit2.HttpException
 
 /**
- * Sealed class of Http result
+ * Sealed class of HTTP result
  */
 @Suppress("unused")
-sealed class Result<out T> {
+public sealed class Result<out T : Any> {
     /**
      * Successful result of request without errors
      */
-    class Ok<out T>(
-            val value: T,
+    public class Ok<out T : Any>(
+            public val value: T,
             override val response: Response
     ) : Result<T>(), ResponseResult
 
     /**
      * HTTP error
      */
-    class Error(
+    public class Error(
             override val exception: HttpException,
             override val response: Response
     ) : Result<Nothing>(), ErrorResult, ResponseResult
@@ -28,7 +28,7 @@ sealed class Result<out T> {
      * Network exception occurred talking to the server or when an unexpected
      * exception occurred creating the request or processing the response
      */
-    class Exception(
+    public class Exception(
             override val exception: Throwable
     ) : Result<Nothing>(), ErrorResult
 
@@ -37,33 +37,33 @@ sealed class Result<out T> {
 /**
  * Interface for [Result] classes with [okhttp3.Response]: [Result.Ok] and [Result.Error]
  */
-interface ResponseResult {
+public interface ResponseResult {
     val response: Response
 }
 
 /**
  * Interface for [Result] classes that contains [Throwable]: [Result.Error] and [Result.Exception]
  */
-interface ErrorResult {
+public interface ErrorResult {
     val exception: Throwable
 }
 
 /**
  * Returns [Result.Ok.value] or `null`
  */
-fun <T> Result<T>.getOrNull() =
+public fun <T : Any> Result<T>.getOrNull() =
         if (this is Result.Ok) this.value else null
 
 /**
  * Returns [Result.Ok.value] or [default]
  */
-fun <T> Result<T>.getOrDefault(default: T) =
+public fun <T : Any> Result<T>.getOrDefault(default: T) =
         getOrNull() ?: default
 
 /**
  * Returns [Result.Ok.value] or throw [throwable] or [ErrorResult.exception]
  */
-fun <T> Result<T>.getOrThrow(throwable: Throwable? = null): T {
+public fun <T : Any> Result<T>.getOrThrow(throwable: Throwable? = null): T {
     return when (this) {
         is Result.Ok -> value
         is Result.Error -> throw throwable ?: exception

--- a/src/main/kotlin/ru/gildor/coroutines/retrofit/Result.kt
+++ b/src/main/kotlin/ru/gildor/coroutines/retrofit/Result.kt
@@ -14,7 +14,11 @@ public sealed class Result<out T : Any> {
     public class Ok<out T : Any>(
             public val value: T,
             override val response: Response
-    ) : Result<T>(), ResponseResult
+    ) : Result<T>(), ResponseResult {
+        override fun toString(): String {
+            return "Result.Ok{value=$value, response=$response}"
+        }
+    }
 
     /**
      * HTTP error
@@ -22,7 +26,11 @@ public sealed class Result<out T : Any> {
     public class Error(
             override val exception: HttpException,
             override val response: Response
-    ) : Result<Nothing>(), ErrorResult, ResponseResult
+    ) : Result<Nothing>(), ErrorResult, ResponseResult {
+        override fun toString(): String {
+            return "Result.Error{exception=$exception}"
+        }
+    }
 
     /**
      * Network exception occurred talking to the server or when an unexpected
@@ -30,7 +38,11 @@ public sealed class Result<out T : Any> {
      */
     public class Exception(
             override val exception: Throwable
-    ) : Result<Nothing>(), ErrorResult
+    ) : Result<Nothing>(), ErrorResult {
+        override fun toString(): String {
+            return "Result.Exception{$exception}"
+        }
+    }
 
 }
 

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/ResultTest.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/ResultTest.kt
@@ -1,7 +1,6 @@
 package ru.gildor.coroutines.retrofit
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.*
 import org.junit.Test
 import retrofit2.HttpException
 import ru.gildor.coroutines.retrofit.util.errorResponse
@@ -11,7 +10,7 @@ class ResultTest {
     private val result = "result"
     private val default = "default"
     private val ok = Result.Ok(result, okHttpResponse())
-    private val error = Result.Error(HttpException(errorResponse()), okHttpResponse(401))
+    private val error = Result.Error(HttpException(errorResponse<Nothing>()), okHttpResponse(401))
     private val exception = Result.Exception(IllegalArgumentException())
     @Test
     fun getOrNull() {

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/ResultTest.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/ResultTest.kt
@@ -11,7 +11,7 @@ class ResultTest {
     private val default = "default"
     private val ok = Result.Ok(result, okHttpResponse())
     private val error = Result.Error(HttpException(errorResponse<Nothing>()), okHttpResponse(401))
-    private val exception = Result.Exception(IllegalArgumentException())
+    private val exception = Result.Exception(IllegalArgumentException("Exception message"))
     @Test
     fun getOrNull() {
         assertEquals(result, ok.getOrNull())
@@ -44,5 +44,29 @@ class ResultTest {
     @Test(expected = IllegalStateException::class)
     fun getOrThrowCustomException() {
         exception.getOrThrow(IllegalStateException("Custom!"))
+    }
+
+    @Test
+    fun okToString() {
+        assertEquals(
+                "Result.Ok{value=result, response=Response{protocol=http/1.1, code=200, message=mock response, url=http://localhost/}}",
+                ok.toString()
+        )
+    }
+
+    @Test
+    fun errorToString() {
+        assertEquals(
+                "Result.Error{exception=retrofit2.HttpException: HTTP 400 Response.error()}",
+                error.toString()
+        )
+    }
+
+    @Test
+    fun exceptionToString() {
+        assertEquals(
+                "Result.Exception{java.lang.IllegalArgumentException: Exception message}",
+                exception.toString()
+        )
     }
 }

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/util/MockedCall.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/util/MockedCall.kt
@@ -9,15 +9,15 @@ import retrofit2.Callback
 import retrofit2.HttpException
 import retrofit2.Response
 
-class MockedCall(
-        val ok: String? = null,
+class MockedCall<T>(
+        val ok: T? = null,
         val error: HttpException? = null,
         val exception: Throwable? = null
-) : Call<String> {
-    var executed: Boolean = false
-    var cancelled: Boolean = false
+) : Call<T> {
+    private var executed: Boolean = false
+    private var cancelled: Boolean = false
 
-    override fun execute(): Response<String> {
+    override fun execute(): Response<T> {
         markAsExecuted()
         return when {
             ok != null -> Response.success(ok)
@@ -27,7 +27,7 @@ class MockedCall(
         }
     }
 
-    override fun enqueue(callback: Callback<String>) {
+    override fun enqueue(callback: Callback<T>) {
         markAsExecuted()
         when {
             ok != null -> callback.onResponse(this, Response.success(ok))
@@ -40,7 +40,7 @@ class MockedCall(
 
     override fun isExecuted() = executed
 
-    override fun clone(): Call<String> = throw IllegalStateException("Not mocked")
+    override fun clone(): Call<T> = throw IllegalStateException("Not mocked")
 
     override fun request(): Request = throw IllegalStateException("Not mocked")
 
@@ -55,7 +55,7 @@ class MockedCall(
 
 }
 
-fun errorResponse(code: Int = 400, message: String = "Error response $code"): Response<String> =
+fun <T> errorResponse(code: Int = 400, message: String = "Error response $code"): Response<T> =
         Response.error(code, ResponseBody.create(MediaType.parse("text/plain"), message))
 
 fun okHttpResponse(code: Int = 200): okhttp3.Response = okhttp3.Response.Builder()

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/util/NullBodyCall.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/util/NullBodyCall.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.gildor.coroutines.retrofit.util
+
+import okhttp3.Request
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+/**
+ * Retrofit Call implementation that always returns `null` body
+ */
+class NullBodyCall<T : Any?> : Call<T> {
+    private var executed: Boolean = false
+    private var cancelled: Boolean = false
+
+    override fun execute(): Response<T> {
+        markAsExecuted()
+        return Response.success(null)
+    }
+
+    override fun enqueue(callback: Callback<T>) {
+        callback.onResponse(this, Response.success(null))
+    }
+
+    override fun isCanceled() = cancelled
+
+    override fun isExecuted() = executed
+
+    override fun clone(): Call<T> = throw IllegalStateException("Not mocked")
+
+    override fun request(): Request = throw IllegalStateException("Not mocked")
+
+    private fun markAsExecuted() {
+        if (executed) throw IllegalStateException("Request already executed")
+        executed = true
+    }
+
+    override fun cancel() {
+        cancelled = true
+    }
+
+}


### PR DESCRIPTION
`.await()` and `.awaitResult()` can be used now only with non-nullable types of result
and throw NullPointerException in case of null body