### PR TITLE
 Updated kotlin to 1.2.41 and coroutines to 0.23.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Version 0.10.1 (2017-06-12)
+
+- [kotlinx.coroutines 0.23.1](https://github.com/Kotlin/kotlinx.coroutines/releases/)
+- Compiled against Kotlin 1.2.41
+
 ## Version 0.10.0 (2017-04-26)
 
 - [Retrofit 2.4.0](https://github.com/square/retrofit/blob/parent-2.4.0/CHANGELOG.md#version-240-2018-03-14)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download the [JAR](https://bintray.com/gildor/maven/kotlin-coroutines-retrofit#f
 Gradle:
 
 ```groovy
-compile 'ru.gildor.coroutines:kotlin-coroutines-retrofit:0.10.0'
+compile 'ru.gildor.coroutines:kotlin-coroutines-retrofit:0.10.1'
 ```
 
 Maven:
@@ -23,7 +23,7 @@ Maven:
 <dependency>
   <groupId>ru.gildor.coroutines</groupId>
   <artifactId>kotlin-coroutines-retrofit</artifactId>
-  <version>0.10.0</version>
+  <version>0.10.1</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.2.40"
+    id("org.jetbrains.kotlin.jvm") version "1.2.41"
     id("com.jfrog.bintray") version "1.7.3"
     jacoco
     `maven-publish`
@@ -34,7 +34,7 @@ java {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib")
-    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.5")
+    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:0.23.1")
     compile("com.squareup.retrofit2:retrofit:2.4.0")
     testCompile("junit:junit:4.12")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 group = "ru.gildor.coroutines"
-version = "0.10.0"
+version = "0.10.1"
 description = "Provides Kotlin Coroutines suspendable await() extensions for Retrofit Call"
 
 repositories {

--- a/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
+++ b/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
@@ -100,7 +100,7 @@ public suspend fun <T : Any> Call<T>.awaitResult(): Result<T> {
 }
 
 private fun Call<*>.registerOnCompletion(continuation: CancellableContinuation<*>) {
-    continuation.invokeOnCompletion {
+    continuation.invokeOnCancellation {
         if (continuation.isCancelled)
             try {
                 cancel()

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/CallAwaitTest.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/CallAwaitTest.kt
@@ -11,6 +11,7 @@ import retrofit2.HttpException
 import ru.gildor.coroutines.retrofit.util.MockedCall
 import ru.gildor.coroutines.retrofit.util.NullBodyCall
 import ru.gildor.coroutines.retrofit.util.errorResponse
+import kotlin.coroutines.experimental.coroutineContext
 
 private const val DONE = "Done!"
 


### PR DESCRIPTION
This update fixes issues caused by breaking changes in kotlin coroutines 0.23.0:

1. invokeOnCompletion() was deprecated. Using invokeOnCancellation() instead.
2. CoroutineScope.coroutineContext was deprecated. Using top-level function coroutineContext instead.