### PR TITLE
Remove unneeded isCancelled check

### DIFF
--- a/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
+++ b/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
@@ -101,11 +101,10 @@ public suspend fun <T : Any> Call<T>.awaitResult(): Result<T> {
 
 private fun Call<*>.registerOnCompletion(continuation: CancellableContinuation<*>) {
     continuation.invokeOnCancellation {
-        if (continuation.isCancelled)
-            try {
-                cancel()
-            } catch (ex: Throwable) {
-                //Ignore cancel exception
-            }
+        try {
+            cancel()
+        } catch (ex: Throwable) {
+            //Ignore cancel exception
+        }
     }
 }


### PR DESCRIPTION
This is no longer since `invokeOnCompletion { ... }` (deprected since) has been replaced by `invokeOnCancellation { ... }`.

Closes #40 