### PR TITLE
Version 0.12.0-eap13 - stable coroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 0.12.0-eap13 (2017-08-04) - Stable coroutines
+
+First version of kotlin-coroutines-retrofit based on stable coroutines API from Kotlin 1.3
+Compiled against Kotlin 1.3-M1 and kotlinx.coroutines 0.24.0-eap13 (also based on stable API)
+ 
+
 ## Version 0.12.0 (2017-08-04)
 
 - [kotlinx.coroutines 0.24.0](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/0.24.0)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ This is a small library that provides the [Kotlin Coroutines](https://github.com
 
 Based on [kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines) implementation.
 
-This branch uses Kotlin experimental package `kotlin.coroutines.experimental` (pre-1.3).
-
-Migration to package stable `kotlin.coroutines` package is planned and work in progress.
+This branch uses stable version of Kotlin coroutines and work only on Kotlin 1.3 (including EAP builds)
 
 ## Download
 Download the [JAR](https://bintray.com/gildor/maven/kotlin-coroutines-retrofit#files/ru/gildor/coroutines/kotlin-coroutines-retrofit):
@@ -18,7 +16,7 @@ Download the [JAR](https://bintray.com/gildor/maven/kotlin-coroutines-retrofit#f
 Gradle:
 
 ```groovy
-compile 'ru.gildor.coroutines:kotlin-coroutines-retrofit:0.12.0'
+compile 'ru.gildor.coroutines:kotlin-coroutines-retrofit:0.12.0-eap13'
 ```
 
 Maven:getOrThrow
@@ -27,7 +25,7 @@ Maven:getOrThrow
 <dependency>
   <groupId>ru.gildor.coroutines</groupId>
   <artifactId>kotlin-coroutines-retrofit</artifactId>
-  <version>0.12.0</version>
+  <version>0.12.0-eap13</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.2.60"
+    id("org.jetbrains.kotlin.jvm") version "1.3-M1"
     id("com.jfrog.bintray") version "1.8.4"
     jacoco
     `maven-publish`
@@ -20,11 +20,12 @@ plugins {
 }
 
 group = "ru.gildor.coroutines"
-version = "0.12.0"
+version = "0.12.0-eap13"
 description = "Provides Kotlin Coroutines suspendable await() extensions for Retrofit Call"
 
 repositories {
     jcenter()
+    maven("http://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 java {
@@ -34,13 +35,9 @@ java {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib")
-    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:0.24.0")
+    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:0.24.0-eap13")
     compile("com.squareup.retrofit2:retrofit:2.4.0")
     testCompile("junit:junit:4.12")
-}
-
-kotlin {
-    experimental.coroutines = Coroutines.ENABLE
 }
 
 /* Code coverage */

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,11 @@
 rootProject.name = "kotlin-coroutines-retrofit"
+
+enableFeaturePreview("STABLE_PUBLISHING")
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        jcenter()
+        maven("http://dl.bintray.com/kotlin/kotlin-eap")
+    }
+}

--- a/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
+++ b/src/main/kotlin/ru/gildor/coroutines/retrofit/CallAwait.kt
@@ -16,12 +16,14 @@
 
 package ru.gildor.coroutines.retrofit
 
-import kotlinx.coroutines.experimental.CancellableContinuation
-import kotlinx.coroutines.experimental.suspendCancellableCoroutine
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.HttpException
 import retrofit2.Response
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Suspend extension that allows suspend [Call] inside of a coroutine.
@@ -32,18 +34,14 @@ public suspend fun <T : Any> Call<T>.await(): T {
     return suspendCancellableCoroutine { continuation ->
         enqueue(object : Callback<T> {
             override fun onResponse(call: Call<T>?, response: Response<T?>) {
-                if (response.isSuccessful) {
-                    val body = response.body()
-                    if (body == null) {
-                        continuation.resumeWithException(
-                            NullPointerException("Response body is null: $response")
-                        )
+                continuation.resumeWith(SuccessOrFailure.runCatching {
+                    if (response.isSuccessful) {
+                        response.body()
+                            ?: throw NullPointerException("Response body is null: $response")
                     } else {
-                        continuation.resume(body)
+                        throw HttpException(response)
                     }
-                } else {
-                    continuation.resumeWithException(HttpException(response))
-                }
+                })
             }
 
             override fun onFailure(call: Call<T>, t: Throwable) {
@@ -91,7 +89,7 @@ public suspend fun <T : Any> Call<T>.awaitResult(): Result<T> {
     return suspendCancellableCoroutine { continuation ->
         enqueue(object : Callback<T> {
             override fun onResponse(call: Call<T>?, response: Response<T>) {
-                continuation.resume(
+                continuation.resumeWith(SuccessOrFailure.runCatching {
                     if (response.isSuccessful) {
                         val body = response.body()
                         if (body == null) {
@@ -102,7 +100,7 @@ public suspend fun <T : Any> Call<T>.awaitResult(): Result<T> {
                     } else {
                         Result.Error(HttpException(response), response.raw())
                     }
-                )
+                })
             }
 
             override fun onFailure(call: Call<T>, t: Throwable) {

--- a/src/test/kotlin/ru/gildor/coroutines/retrofit/CallAwaitTest.kt
+++ b/src/test/kotlin/ru/gildor/coroutines/retrofit/CallAwaitTest.kt
@@ -16,10 +16,10 @@
 
 package ru.gildor.coroutines.retrofit
 
-import kotlinx.coroutines.experimental.CoroutineScope
-import kotlinx.coroutines.experimental.Unconfined
-import kotlinx.coroutines.experimental.async
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Unconfined
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -32,7 +32,7 @@ import retrofit2.HttpException
 import ru.gildor.coroutines.retrofit.util.MockedCall
 import ru.gildor.coroutines.retrofit.util.NullBodyCall
 import ru.gildor.coroutines.retrofit.util.errorResponse
-import kotlin.coroutines.experimental.coroutineContext
+import kotlin.coroutines.coroutineContext
 
 private const val DONE = "Done!"
 


### PR DESCRIPTION
First version of kotlin-coroutines-retrofit based on stable coroutines API from Kotlin 1.3
Compiled against Kotlin 1.3-M1 and kotlinx.coroutines 0.24.0-eap13 (also based on stable API)

Migration to SuccessOrFailure