### PR TITLE
🐛 Fix sources JAR being empty

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ val releaseTag = "v${project.version}"
 val sourcesJar by tasks.creating(Jar::class) {
     dependsOn("classes")
     classifier = "sources"
-    from(sourceSets["main"].allJava)
+    from(sourceSets["main"].allSource)
 }
 
 val javadocJar by tasks.creating(Jar::class) {


### PR DESCRIPTION
Fixes #47.

The sources JAR was empty. Now it isn't anymore. Result:

```bash
$ ./gradlew sourcesJar
$ jar -tf ./build/libs/kotlin-coroutines-retrofit-1.0.0-sources.jar
META-INF/
META-INF/MANIFEST.MF
ru/
ru/gildor/
ru/gildor/coroutines/
ru/gildor/coroutines/retrofit/
ru/gildor/coroutines/retrofit/Result.kt
ru/gildor/coroutines/retrofit/CallAwait.kt
```