### PR TITLE
updated parallel requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ fun main(args: Array<String>): Unit = runBlocking {
 
 ## Parallel requests
 
-Sometimes you want to run a few requests in parallel and don't want to wait for the previous request to make the next one.
-You can do that by wrapping calls with `kotlinx.coroutines` [async()](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/async.html)
+By wrapping call with `kotlinx.coroutines` [async()](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/async.html), you may run a few requests parallelly without waiting for the previous request.
 
 
 ```kotlin


### PR DESCRIPTION
-Sometimes you want to run a few requests in parallel and don't want to wait for the previous request to make the next one. You can do that by wrapping calls with kotlinx.coroutines async()
Revision:
By wrapping call with kotlinx.coroutines async(), you may run a few requests parallelly without waiting for the previous request.
updated #50 
