### PR TITLE
Update to kotlinx-coroutines 1.2.2 and kotlin 1.3.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Version
 
+- Compiled against [Kotlin 1.3.41](https://github.com/JetBrains/kotlin/releases/tag/v1.3.41)
 - [kotlinx.coroutines 1.2.2](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.2.2)
 
 ## Version 1.1.0 (2019-02-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Version
+
+- [kotlinx.coroutines 1.2.2](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.2.2)
+
 ## Version 1.1.0 (2019-02-12)
 
 - [Retrofit 2.5.0](https://github.com/square/retrofit/blob/parent-2.5.0/CHANGELOG.md#version-250-2018-11-18)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ import java.net.URL
 plugins {
     jacoco
     `maven-publish`
-    id("org.jetbrains.kotlin.jvm") version "1.3.21"
+    id("org.jetbrains.kotlin.jvm") version "1.3.41"
     id("com.jfrog.bintray") version "1.8.4"
     id("org.jetbrains.dokka") version "0.9.17"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ java {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib")
-    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1")
+    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2")
     compile("com.squareup.retrofit2:retrofit:2.5.0")
     testCompile("junit:junit:4.12")
 }


### PR DESCRIPTION
# Description

- I prepared an update to the next version of kotlinx-coroutines.
- I have chosen [kotlinx-coroutines 1.2.2](https://github.com/Kotlin/kotlinx.coroutines/blob/master/CHANGES.md#version-122) and the [kotlin 1.3.41](https://github.com/JetBrains/kotlin/releases/tag/v1.3.41) since kotlinx-coroutines 1.2.2 has a transitive dependency to kotlin 1.3.40.
- I also documented the changes in the dependency tree in the commit messages (see below).

# Releasing

- I suggest releasing this update as `ru.gildor.coroutines:kotlin-coroutines-retrofit:2.0.0` to allow users to update gradually.
- The next version - [kotlinx-coroutines 1.3.2](https://github.com/Kotlin/kotlinx.coroutines/blob/master/CHANGES.md#version-132) - should be released as `ru.gildor.coroutines:kotlin-coroutines-retrofit:3.0.0` later on.

# Commits in order

- Use kotlinx-coroutines-core v.1.2.2.
  - Changelog: https://github.com/Kotlin/kotlinx.coroutines/blob/master/CHANGES.md#version-122
  - Updates in the dependency tree:
    ``` java
    org.jetbrains.kotlin:kotlin-stdlib:1.3.21 -> 1.3.40
    org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2
    -> org.jetbrains.kotlin:kotlin-stdlib:1.3.40
    ```

- Use kotlin 1.3.41.
  - Changelog: https://github.com/JetBrains/kotlin/releases/tag/v1.3.41
  - Updates in the dependency tree:
    ``` java
    org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2
    -> org.jetbrains.kotlin:kotlin-stdlib:1.3.40 -> 1.3.41
    ```